### PR TITLE
Update first_issue_en.asm

### DIFF
--- a/news_en/first_issue_en.asm
+++ b/news_en/first_issue_en.asm
@@ -1316,7 +1316,7 @@ TrainerRankingsRankingsScreen: ; $0CBD
 .rankingsEntryBattleTowerWinsText
 	news_text_start
 	news_text_ranking_indicator 3
-	news_text_ranking_text 0, 7, 7
+	news_text_ranking_text 0, 7, 8
 	news_text_ranking_number 20, 2, 5, 5, 0, 0
 	news_text_end
 	db "@"
@@ -1324,7 +1324,7 @@ TrainerRankingsRankingsScreen: ; $0CBD
 .rankingsEntryBugCatchingContestHighScoreText
 	news_text_start
 	news_text_ranking_indicator 3
-	news_text_ranking_text 0, 7, 7
+	news_text_ranking_text 0, 7, 8
 	news_text_ranking_number 20, 2, 5, 5, 0, 0
 	news_text_end
 	db "@"
@@ -1332,7 +1332,7 @@ TrainerRankingsRankingsScreen: ; $0CBD
 .rankingsEntryLargestMagikarpText
 	news_text_start
 	news_text_ranking_indicator 3
-	news_text_ranking_text 0, 7, 7
+	news_text_ranking_text 0, 7, 8
 	news_text_ranking_number 20, 2 | PRINTNUM_LEADINGZEROS, 4, 5, 4, "<DOT>"
 	news_text_end
 	db "@"


### PR DESCRIPTION
Moved ranking scores to the right one tile to account for longer EN player names.